### PR TITLE
Add missing alt property to image tags

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -36,7 +36,7 @@
 <body>
   <header>
     <div>
-      <img src="SMALL/logo_menu.png" width="112px" height="33px" style="cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})"/>
+      <img src="SMALL/logo_menu.png" alt="Hash Menu Logo" width="112px" height="33px" style="cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})"/>
       <a class="header-link home" onclick="window.scroll({ top: 0 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
         home
       </a>
@@ -50,11 +50,11 @@
         contact
       </a>
       <a class="change-language" href="../index.html">
-        <img src="BT_PT@2x.png"/>
+        <img src="BT_PT@2x.png" alt="Switch to portuguese language"/>
       </a>
       
       <a class="header-link blue" href="https://www.linkedin.com/company/hashoficial/life/" target="_blank">
-        work with us <img src="SMALL/next.png" width="7px" height="11px" style="margin-left: 8px;"/>
+        work with us <img src="SMALL/next.png" alt="Right arrow icon" width="7px" height="11px" style="margin-left: 8px;"/>
       </a>
     </div>
   </header>
@@ -62,10 +62,10 @@
   <div class="container">
 
     <div class="left-box ilustras hide-big">
-      <img src="./ILUSTRA/ILU_4.png"/>
-      <img src="./ILUSTRA/ILU_3.png"/>
-      <img src="./ILUSTRA/ILU_2.png"/>
-      <img src="./ILUSTRA/ILU_1.png"/>
+      <img src="./ILUSTRA/ILU_4.png" alt="An illustration of the Hash logo on top of some eletronic blocks"/>
+      <img src="./ILUSTRA/ILU_3.png" alt="An illustration of an eletronic device that looks like a chip, with modules to be inserted"/>
+      <img src="./ILUSTRA/ILU_2.png" alt="An illustration with a brain, paper money and some blocks floating on a eletric device that looks like a chip"/>
+      <img src="./ILUSTRA/ILU_1.png" alt="Futuristic city illustration, with flying cars, buildings and with all connected"/>
     </div>
 
     <div class="left-box bg-squares-1">
@@ -79,25 +79,25 @@
       </span>
 			<div style="margin-top: 30px;display: flex;" class="bg1-3">
 				<a class="button" href="#" onclick="window.scroll({ top: 850 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
-					about <img src="SMALL/down.png" width="16px" height="16px" style="margin-left: 8px;"/>
+					about <img src="SMALL/down.png" alt="Down arrow icon" width="16px" height="16px" style="margin-left: 8px;"/>
 				</a>
 				<a class="button blue" href="#" onclick="window.scroll({ top: 2650 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
-					contact <img src="SMALL/talk.png" width="16px" height="15px" style="margin-left: 5px;"/>
+					contact <img src="SMALL/talk.png" alt="Comic like balloon icon" width="16px" height="15px" style="margin-left: 5px;"/>
 				</a>
 			</div>
     </div>
 
     <div class="right-box">
-      <img class="ilustra animation-4" src="./ILUSTRA/ILU_4.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="ilustra animation-3" src="./ILUSTRA/ILU_3.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="tower t1" src="./ILUSTRA/FORNECEDORES.png" width="79px" height="108px"           style="transform: translate(-197px, -74px);">
-      <img class="tower t2" src="./ILUSTRA/CAPTURA.png" width="79px" height="108px"            style="transform: translate(-115px, -115px);">
-      <img class="tower t3" src="./ILUSTRA/BANKING.png" width="79px" height="108px"             style="transform: translate(-31px, -158px);">
-      <img class="tower t4" src="./ILUSTRA/CONCILIAÇÃO.png" width="79px" height="108px"       style="transform: translate(4px, 55px);">
-      <img class="tower t5" src="./ILUSTRA/CARDS.png" width="79px" height="108px"           style="transform: translate(90px, 2px);">
-      <img class="tower t6" src="./ILUSTRA/WALLET.png" width="79px" height="108px"      style="transform: translate(171px, -46px);">
-      <img class="ilustra animation-2" src="./ILUSTRA/ILU_2.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="ilustra animation-1" src="./ILUSTRA/ILU_1.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-4" src="./ILUSTRA/ILU_4.png" alt="An illustration of the Hash logo on top of some eletronic blocks" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-3" src="./ILUSTRA/ILU_3.png" alt="An illustration of an eletronic device that looks like a chip, with modules to be inserted" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="tower t1" src="./ILUSTRA/FORNECEDORES.png" alt="Suppliers illustration. Three avatars with ties" width="79px" height="108px"           style="transform: translate(-197px, -74px);">
+      <img class="tower t2" src="./ILUSTRA/CAPTURA.png" alt="Payment terminal capture illustration" width="79px" height="108px"            style="transform: translate(-115px, -115px);">
+      <img class="tower t3" src="./ILUSTRA/BANKING.png" alt="Banking illustration" width="79px" height="108px"             style="transform: translate(-31px, -158px);">
+      <img class="tower t4" src="./ILUSTRA/CONCILIAÇÃO.png" alt="Conciliation illustration. An icon with a 'V' verification check" width="79px" height="108px"       style="transform: translate(4px, 55px);">
+      <img class="tower t5" src="./ILUSTRA/CARDS.png" alt="Credit cards illustration" width="79px" height="108px"           style="transform: translate(90px, 2px);">
+      <img class="tower t6" src="./ILUSTRA/WALLET.png" alt="Wallet illustration" width="79px" height="108px"      style="transform: translate(171px, -46px);">
+      <img class="ilustra animation-2" src="./ILUSTRA/ILU_2.png" alt="An illustration with a brain, paper money and some blocks floating on a eletric device that looks like a chip" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-1" src="./ILUSTRA/ILU_1.png" alt="Futuristic city illustration, with flying cars, buildings and with all connected" width="605px" height="830px" style="transform:translate(0, 20px)"/>
     </div>
 
 
@@ -107,7 +107,7 @@
       <h1 class="bg2-1">
         WE<br>
         ARE<br>
-        <img src="SMALL/HASH.png" width="400px" height="171px">
+        <img src="SMALL/HASH.png" alt="Hash name" width="400px" height="171px">
       </h1>
       <span class="span-header bg2-2">
         <!-- Com nossa plataforma whitelabel e plug-and-play, eliminamos o tempo de implementação, reduzimos o investimento inicial e os custos operacionais em até 95%.
@@ -244,19 +244,19 @@
       <div>
         <div>
           <div class="box1-6">
-            <img src="ILUSTRA/CAPTURA.png" class="tower-1-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CAPTURA.png" alt="Payment terminal capture illustration" class="tower-1-final" width="54px" height="86px"/>
             <h3>
               White label payment terminals            
             </h3>
           </div>
           <div class="box2-6">
-            <img src="ILUSTRA/BANKING.png" class="tower-4-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/BANKING.png" alt="Banking illustration" class="tower-4-final" width="54px" height="86px"/>
             <h3>
               Financial management and control systems
             </h3>
           </div>
           <div class="box3-6">
-            <img src="ILUSTRA/WALLET.png" class="tower-5-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/WALLET.png" alt="Wallet illustration" class="tower-5-final" width="54px" height="86px"/>
             <h3>
               Digital wallets for your customers
             </h3>
@@ -264,19 +264,19 @@
         </div>
         <div style="margin-top: 30px;">
           <div class="box4-6">
-            <img src="ILUSTRA/FORNECEDORES.png" class="tower-2-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/FORNECEDORES.png" alt="Suppliers illustration. Three avatars with ties" class="tower-2-final" width="54px" height="86px"/>
             <h3>
               Customizable business rules
             </h3>
           </div>
           <div class="box5-6">
-            <img src="ILUSTRA/CONCILIAÇÃO.png" class="tower-3-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CONCILIAÇÃO.png" alt="Conciliation illustration. An icon with a 'V' verification check" class="tower-3-final" width="54px" height="86px"/>
             <h3>
               Financial reconciliation and control panels
             </h3>
           </div>
           <div class="box6-6">
-            <img src="ILUSTRA/CARDS.png" class="tower-6-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CARDS.png" alt="Credit cards illustration" class="tower-6-final" width="54px" height="86px"/>
             <h3>
               Management and prepayment of receivables
             </h3>
@@ -289,19 +289,19 @@
       <div>
         <div>
           <div class="box1-6">
-            <img src="ILUSTRA/CAPTURA.png" class="tower-1-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CAPTURA.png" alt="Payment terminal capture illustration" class="tower-1-final" width="54px" height="86px"/>
             <h3>
               White label payment terminals            
             </h3>
           </div>
           <div class="box2-6">
-            <img src="ILUSTRA/BANKING.png" class="tower-4-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/BANKING.png" alt="Banking illustration" class="tower-4-final" width="54px" height="86px"/>
             <h3>
               Financial management and control systems
             </h3>
           </div>
           <div class="box3-6">
-            <img src="ILUSTRA/WALLET.png" class="tower-5-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/WALLET.png" alt="Wallet illustration" class="tower-5-final" width="54px" height="86px"/>
             <h3>
               Digital wallets for your customers
             </h3>
@@ -309,19 +309,19 @@
         </div>
         <div style="margin-top: 30px;">
           <div class="box4-6">
-            <img src="ILUSTRA/FORNECEDORES.png" class="tower-2-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/FORNECEDORES.png" alt="Suppliers illustration. Three avatars with ties" class="tower-2-final" width="54px" height="86px"/>
             <h3>
               Customizable business rules
             </h3>
           </div>
           <div class="box5-6">
-            <img src="ILUSTRA/CONCILIAÇÃO.png" class="tower-3-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CONCILIAÇÃO.png" alt="Conciliation illustration. An icon with a 'V' verification check" class="tower-3-final" width="54px" height="86px"/>
             <h3>
               Financial reconciliation and control panels
             </h3>
           </div>
           <div class="box6-6">
-            <img src="ILUSTRA/CARDS.png" class="tower-6-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CARDS.png" alt="Credit cards illustration" class="tower-6-final" width="54px" height="86px"/>
             <h3>
               Management and prepayment of receivables
             </h3>
@@ -386,14 +386,14 @@
   </div>
 
   <footer>
-    <img src="SMALL/logo_footer.png" width="91px" height="91px" style="margin-left: 20px;cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})">
+    <img src="SMALL/logo_footer.png" alt="Hash logo with name" width="91px" height="91px" style="margin-left: 20px;cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})">
     
     <div class= "info">
-      <div class="location"> <img  class="hide-small" src="SMALL/location.png" width="15px" height="20px"/> <span><b>Av. Brigadeiro Faria Lima 1.306, 6 andar - São Paulo, SP</b></span> </div>
+      <div class="location"> <img  class="hide-small" src="SMALL/location.png"  alt="Map pin icon" width="15px" height="20px"/> <span><b>Av. Brigadeiro Faria Lima 1.306, 6 andar - São Paulo, SP</b></span> </div>
       <span>© Copyright 2017~2020 Hash Lab Solucoes Pagamento LTDA</span>
     </div>
     <div class="media">
-      <a href="https://www.linkedin.com/company/hashoficial/" target="_blank"> /hashoficial <img src="SMALL/social_linkedin.png" width="22px" height="24px"/> </a>
+      <a href="https://www.linkedin.com/company/hashoficial/" target="_blank"> /hashoficial <img src="SMALL/social_linkedin.png" alt="Linkedin logo" width="22px" height="24px"/> </a>
     </div>
   </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
 <body>
   <header>
     <div>
-      <img src="SMALL/logo_menu.png" width="112px" height="33px" style="cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})"/>
+      <img src="SMALL/logo_menu.png" alt="Hash Menu Logo" width="112px" height="33px" style="cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})"/>
       <a class="header-link home" onclick="window.scroll({ top: 0 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
         início
       </a>
@@ -50,11 +50,11 @@
         contato
       </a>
       <a class="change-language" href="./en/index.html">
-        <img src="BT_EN@2x.png"/>
+        <img src="BT_EN@2x.png" alt="Troca para linguagem inglês"/>
       </a>
       
       <a class="header-link blue" href="https://www.linkedin.com/company/hashoficial/life/" target="_blank">
-        trabalhe conosco <img src="SMALL/next.png" width="7px" height="11px" style="margin-left: 8px;"/>
+        trabalhe conosco <img src="SMALL/next.png" alt="Ícone de uma flecha para a direita" width="7px" height="11px" style="margin-left: 8px;"/>
       </a>
     </div>
   </header>
@@ -62,10 +62,10 @@
   <div class="container">
 
     <div class="left-box ilustras hide-big">
-      <img src="./ILUSTRA/ILU_4.png"/>
-      <img src="./ILUSTRA/ILU_3.png"/>
-      <img src="./ILUSTRA/ILU_2.png"/>
-      <img src="./ILUSTRA/ILU_1.png"/>
+      <img src="./ILUSTRA/ILU_4.png" alt="Ilustração do logo da Hash sobre blocos eletrônicos"/>
+      <img src="./ILUSTRA/ILU_3.png" alt="Ilustração de algo que se assemelha um chip eletrônico com módulos a serem inseridos"/>
+      <img src="./ILUSTRA/ILU_2.png" alt="Ilustração de um cérebro, dinheiro em papel e alguns blocos flutuando sobre o que se assemelha um chip eletrônico"/>
+      <img src="./ILUSTRA/ILU_1.png" alt="Ilustração de uma cidade futurista com carros voadores, prédios e com tudo conectado"/>
     </div>
 
     <div class="left-box bg-squares-1">
@@ -79,25 +79,25 @@
       </span>
 			<div style="margin-top: 30px;display: flex;" class="bg1-3">
 				<a class="button" href="#" onclick="window.scroll({ top: 850 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
-					saiba mais <img src="SMALL/down.png" width="16px" height="16px" style="margin-left: 8px;"/>
+					saiba mais <img src="SMALL/down.png" alt="Ícone flecha para baixo" width="16px" height="16px" style="margin-left: 8px;"/>
 				</a>
 				<a class="button blue" href="#" onclick="window.scroll({ top: 2650 * parseFloat(window.document.body.style.zoom), behavior: 'smooth'})">
-					entre em contato <img src="SMALL/talk.png" width="16px" height="15px" style="margin-left: 5px;"/>
+					entre em contato <img src="SMALL/talk.png" alt="Ícone balão estilo quadrinhos" width="16px" height="15px" style="margin-left: 5px;"/>
 				</a>
 			</div>
     </div>
 
     <div class="right-box">
-      <img class="ilustra animation-4" src="./ILUSTRA/ILU_4.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="ilustra animation-3" src="./ILUSTRA/ILU_3.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="tower t1" src="./ILUSTRA/FORNECEDORES.png" width="79px" height="108px"           style="transform: translate(-197px, -74px);">
-      <img class="tower t2" src="./ILUSTRA/CAPTURA.png" width="79px" height="108px"            style="transform: translate(-115px, -115px);">
-      <img class="tower t3" src="./ILUSTRA/BANKING.png" width="79px" height="108px"             style="transform: translate(-31px, -158px);">
-      <img class="tower t4" src="./ILUSTRA/CONCILIAÇÃO.png" width="79px" height="108px"       style="transform: translate(4px, 55px);">
-      <img class="tower t5" src="./ILUSTRA/CARDS.png" width="79px" height="108px"           style="transform: translate(90px, 2px);">
-      <img class="tower t6" src="./ILUSTRA/WALLET.png" width="79px" height="108px"      style="transform: translate(171px, -46px);">
-      <img class="ilustra animation-2" src="./ILUSTRA/ILU_2.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
-      <img class="ilustra animation-1" src="./ILUSTRA/ILU_1.png" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-4" src="./ILUSTRA/ILU_4.png" alt="Ilustração do logo da Hash sobre blocos eletrônicos" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-3" src="./ILUSTRA/ILU_3.png" alt="Ilustração de algo que se assemelha um chip eletrônico com módulos a serem inseridos" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="tower t1" src="./ILUSTRA/FORNECEDORES.png" alt="Ilustração de fornecedores. Três avatares com gravatas" width="79px" height="108px"           style="transform: translate(-197px, -74px);">
+      <img class="tower t2" src="./ILUSTRA/CAPTURA.png" alt="Ilustração de terminal de pagamento" width="79px" height="108px"            style="transform: translate(-115px, -115px);">
+      <img class="tower t3" src="./ILUSTRA/BANKING.png" alt="Ilustração de um banco" width="79px" height="108px"             style="transform: translate(-31px, -158px);">
+      <img class="tower t4" src="./ILUSTRA/CONCILIAÇÃO.png" alt="Ilustração de conciliação. Um ícone com um 'V' de verificação" width="79px" height="108px"       style="transform: translate(4px, 55px);">
+      <img class="tower t5" src="./ILUSTRA/CARDS.png" alt="Ilustração de cartões de crédito" width="79px" height="108px"           style="transform: translate(90px, 2px);">
+      <img class="tower t6" src="./ILUSTRA/WALLET.png" alt="Ilustração de uma carteira" width="79px" height="108px"      style="transform: translate(171px, -46px);">
+      <img class="ilustra animation-2" src="./ILUSTRA/ILU_2.png" alt="Ilustração de um cérebro, dinheiro em papel e alguns blocos flutuando sobre o que se assemelha um chip eletrônico" width="605px" height="830px" style="transform:translate(0, 20px)"/>
+      <img class="ilustra animation-1" src="./ILUSTRA/ILU_1.png" alt="Ilustração de uma cidade futurista com carros voadores, prédios e com tudo conectado" width="605px" height="830px" style="transform:translate(0, 20px)"/>
     </div>
 
 
@@ -107,7 +107,7 @@
       <h1 class="bg2-1">
         NÓS<br>
         SOMOS<br>
-        A <img src="SMALL/HASH.png" width="400px" height="171px">
+        A <img src="SMALL/HASH.png" alt="Nome da Hash" width="400px" height="171px">
       </h1>
       <span class="span-header bg2-2">
         <!-- Com nossa plataforma whitelabel e plug-and-play, eliminamos o tempo de implementação, reduzimos o investimento inicial e os custos operacionais em até 95%.
@@ -240,19 +240,19 @@
       <div>
         <div>
           <div class="box1-6">
-            <img src="ILUSTRA/CAPTURA.png" class="tower-1-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CAPTURA.png" alt="Ilustração de terminal de pagamento" class="tower-1-final" width="54px" height="86px"/>
             <h3>
               Terminais de pagamentos white label
             </h3>
           </div>
           <div class="box2-6">
-            <img src="ILUSTRA/BANKING.png" class="tower-4-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/BANKING.png" alt="Ilustração de um banco" class="tower-4-final" width="54px" height="86px"/>
             <h3>
               Sistemas de controle e gestão financeira
             </h3>
           </div>
           <div class="box3-6">
-            <img src="ILUSTRA/WALLET.png" class="tower-5-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/WALLET.png" alt="Ilustração de uma carteira" class="tower-5-final" width="54px" height="86px"/>
             <h3>
               Carteiras digitais para seus clientes
             </h3>
@@ -260,19 +260,19 @@
         </div>
         <div style="margin-top: 30px;">
           <div class="box4-6">
-            <img src="ILUSTRA/FORNECEDORES.png" class="tower-2-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/FORNECEDORES.png" alt="Ilustração de fornecedores. Três avatares com gravatas" class="tower-2-final" width="54px" height="86px"/>
             <h3>
               Regras de negócio customizáveis
             </h3>
           </div>
           <div class="box5-6">
-            <img src="ILUSTRA/CONCILIAÇÃO.png" class="tower-3-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CONCILIAÇÃO.png" alt="Ilustração de conciliação. Um ícone com um 'V' de verificação" class="tower-3-final" width="54px" height="86px"/>
             <h3>
               Conciliação financeira e painéis de controle
             </h3>
           </div>
           <div class="box6-6">
-            <img src="ILUSTRA/CARDS.png" class="tower-6-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CARDS.png" alt="Ilustração de cartões de crédito" class="tower-6-final" width="54px" height="86px"/>
             <h3>
               Gestão e antecipação  de recebíveis
             </h3>
@@ -285,19 +285,19 @@
       <div>
         <div>
           <div class="box1-6">
-            <img src="ILUSTRA/CAPTURA.png" class="tower-1-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CAPTURA.png" alt="Ilustração de terminal de pagamento" class="tower-1-final" width="54px" height="86px"/>
             <h3>
               Terminais de pagamentos white label
             </h3>
           </div>
           <div class="box2-6">
-            <img src="ILUSTRA/BANKING.png" class="tower-4-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/BANKING.png" alt="Ilustração de um banco" class="tower-4-final" width="54px" height="86px"/>
             <h3>
               Sistemas de controle e gestão financeira
             </h3>
           </div>
           <div class="box3-6">
-            <img src="ILUSTRA/WALLET.png" class="tower-5-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/WALLET.png" alt="Ilustração de uma carteira" class="tower-5-final" width="54px" height="86px"/>
             <h3>
               Carteiras digitais para seus clientes
             </h3>
@@ -305,19 +305,19 @@
         </div>
         <div style="margin-top: 30px;">
           <div class="box4-6">
-            <img src="ILUSTRA/FORNECEDORES.png" class="tower-2-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/FORNECEDORES.png" alt="Ilustração de fornecedores. Três avatares com gravatas" class="tower-2-final" width="54px" height="86px"/>
             <h3 style="margin-left:-17px;">
               Regras de negócio customizáveis
             </h3>
           </div>
           <div class="box5-6">
-            <img src="ILUSTRA/CONCILIAÇÃO.png" class="tower-3-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CONCILIAÇÃO.png" alt="Ilustração de conciliação. Um ícone com um 'V' de verificação" class="tower-3-final" width="54px" height="86px"/>
             <h3>
               Conciliação financeira e painéis de controle
             </h3>
           </div>
           <div class="box6-6">
-            <img src="ILUSTRA/CARDS.png" class="tower-6-final" width="54px" height="86px"/>
+            <img src="ILUSTRA/CARDS.png" alt="Ilustração de cartões de crédito" class="tower-6-final" width="54px" height="86px"/>
             <h3 style="margin-left:-10px;">
               Gestão e antecipação  de recebíveis
             </h3>
@@ -382,14 +382,14 @@
   </div>
 
   <footer>
-    <img src="SMALL/logo_footer.png" width="91px" height="91px" style="margin-left: 20px;cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})">
+    <img src="SMALL/logo_footer.png" alt="Logo da Hash com o nome escrito" width="91px" height="91px" style="margin-left: 20px;cursor:pointer;" onclick="window.scroll({ top: 0, behavior: 'smooth'})">
     
     <div class= "info">
-      <div class="location"> <img  class="hide-small" src="SMALL/location.png" width="15px" height="20px"/> <span><b>Av. Brigadeiro Faria Lima 1.306, 6 andar - São Paulo, SP</b></span> </div>
+      <div class="location"> <img  class="hide-small" src="SMALL/location.png" alt="Ícone de alfinete de mapa" width="15px" height="20px"/> <span><b>Av. Brigadeiro Faria Lima 1.306, 6 andar - São Paulo, SP</b></span> </div>
       <span>© Copyright 2017~2020 Hash Lab Solucoes Pagamento LTDA</span>
     </div>
     <div class="media">
-      <a href="https://www.linkedin.com/company/hashoficial/" target="_blank"> /hashoficial <img src="SMALL/social_linkedin.png" width="22px" height="24px"/> </a>
+      <a href="https://www.linkedin.com/company/hashoficial/" target="_blank"> /hashoficial <img src="SMALL/social_linkedin.png" alt="Logo da Linkedin" width="22px" height="24px"/> </a>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
The `img` tags were missing the `alt` property which are important to blind people I guess, so I've added them.

However I don't know if they should be in portuguese or english, since the page has both languages. I've added in english since the whole code and properties are in english, but if you feel it should be in portuguese I can translate them 😉 